### PR TITLE
general: Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/*
+zephyr/blobs/*


### PR DESCRIPTION
So build artifacts or binary blobs are not ever staged as a mistake.